### PR TITLE
Scale background image with `pixelated`

### DIFF
--- a/sloanp website/index.html
+++ b/sloanp website/index.html
@@ -17,6 +17,7 @@
 
     #back {
       background-image: url('backgrounds/tre.png');
+      image-rendering: pixelated;
       padding: 30px;
       grid-auto-rows: minmax(auto, auto);
       display: table;


### PR DESCRIPTION
This fixes an issue where the background (`tre.png`) would sometimes look much different than other times, due to scaling issues